### PR TITLE
Fixes to let t/dir.t and t/dists.t pass on Win32

### DIFF
--- a/corpus/make_dists
+++ b/corpus/make_dists
@@ -5,7 +5,7 @@ use warnings;
 use FindBin;       # core
 use Archive::Tar;
 use File::Find;    # core
-use File::Spec::Functions qw(catfile catdir abs2rel);    # core
+use File::Spec::Unix;    # core
 use IO::File;      # core
 use Data::Dumper ();  # core
 
@@ -35,9 +35,9 @@ while( my ($name, $dist) = each %$dists ){
   my $tgz  = $dist->{file} || $dist->{dir} . '.tar.gz';
 
   my $wd = $dist->{cd}
-    ? catdir( $work_dir, $dist->{cd} )
+    ? File::Spec::Unix->catdir( $work_dir, $dist->{cd} )
     : $work_dir;
-  my $fd = catdir( $wd, $dist->{dir} );
+  my $fd = File::Spec::Unix->catdir( $wd, $dist->{dir} );
 
   my @files;
   find({
@@ -51,20 +51,20 @@ while( my ($name, $dist) = each %$dists ){
   );
 
   foreach my $file ( @files ){
-    my $rel = abs2rel($file, $wd);
+    my $rel = File::Spec::Unix->abs2rel($file, $wd);
     my $content = slurp($file);
     $tar->add_data( $rel => $content );
     $struct->{$rel} = $content;
   }
 
-  $tar->write(catfile($work_dir, $tgz), Archive::Tar::COMPRESS_GZIP());
+  $tar->write(File::Spec::Unix->catfile($work_dir, $tgz), Archive::Tar::COMPRESS_GZIP());
   $structs->{$name} = $struct;
 }
 
 {
   local $Data::Dumper::Indent = 1;
   spit(
-    catfile($work_dir, 'structs.pl'),
+    File::Spec::Unix->catfile($work_dir, 'structs.pl'),
     Data::Dumper->Dump( [$structs], ['Dist::Metadata::Test::Structs'] )
   );
 }

--- a/lib/Dist/Metadata/Dist.pm
+++ b/lib/Dist/Metadata/Dist.pm
@@ -341,6 +341,8 @@ sub parse_name_and_version {
       my $dnifile = $path;
       # if it doesn't appear to have an extension fake one to help DistnameInfo
       $dnifile .= '.tar.gz' unless $dnifile =~ /\.[a-z]\w+$/;
+      # DistNameInfo needs the file path to be specified in Unix format
+      $dnifile = $self->path_class_file->new($dnifile)->as_foreign('Unix');
       my $dni  = CPAN::DistnameInfo->new($dnifile);
       my $dni_name    = $dni->dist;
       my $dni_version = $dni->version;


### PR DESCRIPTION
The most recent release does not pass tests on Win32. See for example:
http://www.cpantesters.org/cpan/report/13802652

With these fixes, it passes on Win7 64-bit. Can you test on a Unix platform?
