### PR TITLE
Don't emit warning when dist contains no perl files

### DIFF
--- a/lib/Dist/Metadata.pm
+++ b/lib/Dist/Metadata.pm
@@ -197,10 +197,7 @@ sub determine_packages {
   # TODO: should we limit packages to lib/ if it exists?
   # my @lib = grep { m#^lib/# } @files; @files = @lib if @lib;
 
-  unless (@files) {
-    warn("No perl files found in distribution\n");
-    return {};
-  }
+  return {} if not @files;
 
   my $packages = $self->dist->determine_packages(@files);
 


### PR DESCRIPTION
Hi Randy-

Thanks for the great work on Dist::Metadata.  It has made my current project _so_ much easier!

I noticed that D::M warns when given a dist that contains no perl files.  Rather than squirting stuff directly to STDERR, I suggest warning should be left to the application (or whatever is using D::M).  Alternatively, you could throw an exception.  Either way, I think it would be best to let callers decide what to do when a dist has no perl files.

What do you think?

-Jeff
