### PR TITLE
Don't force the release_status to 'stable'

### DIFF
--- a/corpus/Dist-Metadata-Test-NoMetaFile-DevRelease-0.1_1/README
+++ b/corpus/Dist-Metadata-Test-NoMetaFile-DevRelease-0.1_1/README
@@ -1,0 +1,1 @@
+This "dist" is for testing Dist::Metadata.

--- a/corpus/Dist-Metadata-Test-NoMetaFile-DevRelease-0.1_1/lib/Dist/Metadata/Test/NoMetaFile/DevRelease.pm
+++ b/corpus/Dist-Metadata-Test-NoMetaFile-DevRelease-0.1_1/lib/Dist/Metadata/Test/NoMetaFile/DevRelease.pm
@@ -1,0 +1,4 @@
+package Dist::Metadata::Test::NoMetaFile::DevRelease;
+# ABSTRACT: Fake dist for testing metadata determination
+
+our $VERSION = '0.1_1';

--- a/corpus/make_dists
+++ b/corpus/make_dists
@@ -23,6 +23,9 @@ my $dists = {
   nometafile => {
     dir  => 'Dist-Metadata-Test-NoMetaFile-0.1',
   },
+  nometafile_dev_release => {
+    dir  => 'Dist-Metadata-Test-NoMetaFile-DevRelease-0.1_1',
+  },
   subdir => {
     dir  => 'Dist-Metadata-Test-SubDir-1.5',
     cd   => 'subdir',

--- a/lib/Dist/Metadata.pm
+++ b/lib/Dist/Metadata.pm
@@ -120,7 +120,11 @@ sub default_metadata {
       url     => 'http://search.cpan.org/perldoc?CPAN::Meta::Spec',
     },
     name           => UNKNOWN,
-    release_status => 'stable',
+
+    # strictly speaking, release_status is also required but
+    # CPAN::Meta will figure it out based on the version number.  if
+    # we were to set it explicitly, then we would first need to
+    # examine the version number for '_' or 'TRIAL' or 'RC' etc.
     version        => 0,
 
     # optional

--- a/t/dists.t
+++ b/t/dists.t
@@ -70,6 +70,22 @@ foreach my $test  (
       },
     },
   ],
+[
+    [
+      nometafile_dev_release =>
+      'Dist-Metadata-Test-NoMetaFile-DevRelease-0.1_1',
+    ],
+    {
+      name     => 'Dist-Metadata-Test-NoMetaFile-DevRelease',
+      version  => '0.1_1',
+      provides => {
+        'Dist::Metadata::Test::NoMetaFile::DevRelease' => {
+          file    => 'lib/Dist/Metadata/Test/NoMetaFile/DevRelease.pm',
+          version => '0.1_1',
+        },
+      },
+    },
+  ],
   [
     [
       subdir =>


### PR DESCRIPTION
When using the default metadata (usually because the dist has no metadata file),
we cannot assume that the release_status is 'stable'.  If we assume that
a release is stable, but the version number indicates otherwise, then
CPAN::Meta blows up with this kind of error:

Failed to clean-up 2 metadata. Errors:
'stable' for 'release_status' is invalid for version '0.1_1' (release_status) [Validation: 2]
 at .../Dist/Metadata.pm line 211

By not setting the release_status in the default metadata, CPAN::Meta will
compute it for us, by examining the version number for underscores.

I also added a test case to verify this behavior.
