### PR TITLE
Problems with tarballs with entry with "./" in front

### DIFF
--- a/lib/Dist/Metadata/Dist.pm
+++ b/lib/Dist/Metadata/Dist.pm
@@ -489,7 +489,7 @@ sub remove_root_dir {
   # FIXME: can we use File::Spec for these regexp's instead of [\\/] ?
 
   # grab the root dir from the first file
-  $files[0] =~ m{^([^\\/]+)[\\/]}
+  $files[0] =~ m{^((?:\.[\\/])?[^\\/]+)[\\/]}
     # if not matched quit now
     or return (undef, @files);
 

--- a/lib/Dist/Metadata/Tar.pm
+++ b/lib/Dist/Metadata/Tar.pm
@@ -13,7 +13,10 @@ push(@Dist::Metadata::CARP_NOT, __PACKAGE__);
 
 sub file_content {
   my ( $self, $file ) = @_;
-  return $self->archive->get_content( $self->full_path($file) );
+  my $re = quotemeta( $self->full_path($file) );
+  my($f) = grep { $_->full_path =~ m/^ (?:\.\/)? $re $/x }
+    $self->archive->get_files;
+  $f ? $f->get_content : undef;
 }
 
 sub find_files {

--- a/t/tar_normalize.t
+++ b/t/tar_normalize.t
@@ -1,0 +1,16 @@
+use strict;
+use warnings;
+use Test::More 0.96;
+
+my $mod = 'Dist::Metadata::Tar';
+eval "require $mod" or die $@;
+
+my $file = 'corpus/MsqlCGI-0.8.tar.gz';
+my $tar = $mod->new(file => $file);
+
+my @files = $tar->perl_files;
+is $files[0], 'MsqlCGI-bin/MsqlCGI.pm';
+
+ok $tar->file_content($files[0]);
+
+done_testing;


### PR DESCRIPTION
```
use Carp::Always;
use Dist::Metadata;

$m = Dist::Metadata->new(file => shift);
warn (($m->dist->find_files)[0]);
$m->dist->file_content(($m->dist->perl_files)[0]);
```

```
> perl metadata.pl ~/minicpan/authors/id/A/AL/ALTITUDE/MsqlCGI-0.8.tar.gz
./MsqlCGI-0.8/MsqlCGI-bin/CreateDef.pl at -e line 1.
No such file in archive: 'MsqlCGI-0.8/MsqlCGI-bin/MsqlCGI.pm' at /Users/miyagawa/.plenv/versions/5.16.3/lib/perl5/5.16.3/Archive/Tar.pm line 1581.
        Archive::Tar::_error('Archive::Tar=HASH(0x7fc00c04f090)', 'No such file in archive: \'MsqlCGI-0.8/MsqlCGI-bin/MsqlCGI.pm\'') called at /Users/miyagawa/.plenv/versions/5.16.3/lib/perl5/5.16.3/Archive/Tar.pm line 1038
        Archive::Tar::_find_entry('Archive::Tar=HASH(0x7fc00c04f090)', 'MsqlCGI-0.8/MsqlCGI-bin/MsqlCGI.pm') called at /Users/miyagawa/.plenv/versions/5.16.3/lib/perl5/5.16.3/Archive/Tar.pm line 1074
        Archive::Tar::get_content('Archive::Tar=HASH(0x7fc00c04f090)', 'MsqlCGI-0.8/MsqlCGI-bin/MsqlCGI.pm') called at /Users/miyagawa/.plenv/versions/5.16.3/lib/perl5/site_perl/5.16.3/Dist/Metadata/Tar.pm line 30
        Dist::Metadata::Tar::file_content('Dist::Metadata::Tar=HASH(0x7fc00c174f78)', 'MsqlCGI-0.8/MsqlCGI-bin/MsqlCGI.pm') called at /Users/miyagawa/.plenv/versions/5.16.3/lib/perl5/5.16.3/Archive/Tar.pm line 1581.
        Archive::Tar::_error('Archive::Tar=HASH(0x7fc00c04f090)', 'No such file in archive: \'MsqlCGI-0.8/MsqlCGI-bin/MsqlCGI.pm\'') called at /Users/miyagawa/.plenv/versions/5.16.3/lib/perl5/5.16.3/Archive/Tar.pm line 1038
        Archive::Tar::_find_entry('Archive::Tar=HASH(0x7fc00c04f090)', 'MsqlCGI-0.8/MsqlCGI-bin/MsqlCGI.pm') called at /Users/miyagawa/.plenv/versions/5.16.3/lib/perl5/5.16.3/Archive/Tar.pm line 1074
        Archive::Tar::get_content('Archive::Tar=HASH(0x7fc00c04f090)', 'MsqlCGI-0.8/MsqlCGI-bin/MsqlCGI.pm') called at /Users/miyagawa/.plenv/versions/5.16.3/lib/perl5/site_perl/5.16.3/Dist/Metadata/Tar.pm line 30
        Dist::Metadata::Tar::file_content('Dist::Metadata::Tar=HASH(0x7fc00c174f78)', 'MsqlCGI-0.8/MsqlCGI-bin/MsqlCGI.pm') called at -e line 1
```

This is probably because Dist::Metadata normalizes the path in the tar entry and eliminates the leading `./`.
